### PR TITLE
New accelerated dinf and d8 algorithms not building

### DIFF
--- a/taudem/src/flow_direction.h
+++ b/taudem/src/flow_direction.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <functional>
 
 #include "commonLib.h"
 #include "linearpart.h"


### PR DESCRIPTION
On Ubuntu 18.04 LTS with GDAL and MPICH from apt package manager, I get an error when building d8.cpp and dinf.cpp. All other build targets pass. I use the standard cmake and make commands recommended in the cyber-gis/readme.md. The first error for both build targets is 
```
error: ‘function’ in namespace ‘std’ 
does not name a template type                                                                                              
         typedef std::function<void(bool, std::vector<node>&, bool&, bool&)> update_fn; 
```

Resolved error by adding the following to cybergis-toolkit/taudem/src/flow_direction.h:
```
#include <functional>
```
All targets successfully build after change.